### PR TITLE
Fix font color from HandleClass

### DIFF
--- a/widgets/controls.pas
+++ b/widgets/controls.pas
@@ -1521,6 +1521,7 @@ end;
 procedure TControl.Changed;
 var
   form: TCustomForm;
+  fonthcolor: String;
 
   function AdjustWithPPI(aValue: Integer): Integer;
   begin
@@ -1585,7 +1586,14 @@ begin
         begin
           Style.SetProperty('background-color', JSColor(FColor));
         end;
-      end;
+      end
+      else
+      begin
+        /// Font Color -HandleClass
+        fonthcolor := Style.getPropertyValue('border-color');
+        Style.SetProperty('color',  fonthcolor);
+        UpdateHtmlElementFont(FHandleElement, FFont, False);
+      end;      
 
       /// Bounds
       Style.SetProperty('left', IntToStr(AdjustWithPPI(FLeft)) + 'px');


### PR DESCRIPTION
Gets the font color property from HandleClass and updates it.

Before with Bulma (theme-light):
![BulmaBefore](https://github.com/pascaldragon/Pas2JS_Widget/assets/45245617/3a97a89b-949a-4e92-a749-3d7a0a32c338)

After with Bulma (theme-light):
![BulmaAfter](https://github.com/pascaldragon/Pas2JS_Widget/assets/45245617/e16f913f-54ea-4de8-a4c9-2f6030367f7a)


Before with Bulma (theme-dark):
![BulmaDarkBe](https://github.com/pascaldragon/Pas2JS_Widget/assets/45245617/11003870-6651-4fab-bd2e-f97845a37c0d)


Afert with Bulma (theme-dark):
![BulmaDarkAf](https://github.com/pascaldragon/Pas2JS_Widget/assets/45245617/1fb9ffb6-935e-45fb-82e2-f1dc4e2ebe11)


Before with Bootstrap:
![BootstraBef](https://github.com/pascaldragon/Pas2JS_Widget/assets/45245617/a153073f-ef95-4112-916f-8883eb82595f)

After with Bootstrap:
![BootstrapAf](https://github.com/pascaldragon/Pas2JS_Widget/assets/45245617/06ef569b-ad1b-479a-858b-37cc7e2fc4af)


To apply Bulma's light and dark themes, it is necessary to assign the TWForm color in clNone and in the html file:
```html
<html lang="en" class="theme-dark">
```
Or
```html
<html lang="en" class="theme-light">
```

