### PR TITLE
Implement ScalingDesign in forms

### DIFF
--- a/design/source/webctrls.pas
+++ b/design/source/webctrls.pas
@@ -54,6 +54,7 @@ type
   private
     FHandleClass: string;
     FHandleId: string;
+    FScalingDesign: Boolean;
   published
     property ActiveControl;
     property Align;
@@ -66,7 +67,7 @@ type
     property DesignTimePPI;
     property Enabled;
     property Font;
-    ///property FormType;  
+    ///property FormType;
     property HandleClass: string read FHandleClass write FHandleClass;
     property HandleId: string read FHandleId write FHandleId;
     property KeyPreview;
@@ -93,6 +94,7 @@ type
     property OnResize;
     ///property OnScroll;
     property OnShow;
+    property ScalingDesign: Boolean read FScalingDesign write FScalingDesign default False;
   end;
   TWFormClass = class of TWForm;
 
@@ -133,7 +135,7 @@ type
   { TWDataModule }
 
   TWDataModule = class(TDataModule)
-  end;   
+  end;
   TWDataModuleClass = class of TWDataModule;
 
   { TWComboBox }
@@ -1095,3 +1097,4 @@ begin
 end;
 
 end.
+

--- a/widgets/controls.pas
+++ b/widgets/controls.pas
@@ -235,8 +235,6 @@ type
     FOnMouseWheel: TMouseWheelEvent;
     FOnResize: TNotifyEvent;
     FOnScroll: TNotifyEvent;
-    FHorizontalScale: Single;
-    FVerticalScale: Single;
     function GetClientHeight: NativeInt;
     function GetClientOrigin: TPoint;
     function GetClientRect: TRect;
@@ -368,8 +366,6 @@ type
     property Visible: boolean read FVisible write SetVisible;
     property OnClick: TNotifyEvent read FOnClick write FOnClick;
     property OnResize: TNotifyEvent read FOnResize write FOnResize;
-    property HorizontalScale: Single read FHorizontalScale write FHorizontalScale;
-    property VerticalScale: Single read FVerticalScale write FVerticalScale;
   published
     property Cursor: TCursor read FCursor write SetCursor;
     property Left: NativeInt read FLeft write SetLeft;
@@ -1594,10 +1590,10 @@ begin
       /// Bounds
       if (form <> nil) and form.ScalingDesign and (Parent <> nil) then
       begin
-        Style.SetProperty('left', FloatToStr(FLeft / Parent.Width / Parent.HorizontalScale * 100) + '%');
-        Style.SetProperty('top', FloatToStr(FTop / Parent.Height / Parent.VerticalScale * 100) + '%');
-        Style.SetProperty('width', FloatToStr(FWidth / Parent.Width / Parent.HorizontalScale * 100) + '%');
-        Style.SetProperty('height', FloatToStr(FHeight / Parent.Height / Parent.VerticalScale * 100) + '%');
+        Style.SetProperty('left', FloatToStr(FLeft / Parent.Width / form.HorizontalScale * 100) + '%');
+        Style.SetProperty('top', FloatToStr(FTop / Parent.Height / form.VerticalScale * 100) + '%');
+        Style.SetProperty('width', FloatToStr(FWidth / Parent.Width / form.HorizontalScale * 100) + '%');
+        Style.SetProperty('height', FloatToStr(FHeight / Parent.Height / form.VerticalScale * 100) + '%');
       end
       else
       begin
@@ -2140,8 +2136,6 @@ begin
   FTop := 0;
   FUpdateCount := 0;
   FVisible := True;
-  FHorizontalScale := 1;
-  FVerticalScale := 1;
 end;
 
 destructor TControl.Destroy;

--- a/widgets/controls.pas
+++ b/widgets/controls.pas
@@ -1605,6 +1605,16 @@ begin
         Style.SetProperty('top', IntToStr(AdjustWithPPI(FTop)) + 'px');
         Style.SetProperty('width', IntToStr(AdjustWithPPI(FWidth)) + 'px');
         Style.SetProperty('height', IntToStr(AdjustWithPPI(FHeight)) + 'px');
+
+        /// for scaling design, make sure the form will not be scaled below
+        /// original width / height. This ensures the form will remain
+        /// readable. This also effectively means the form can only scale up,
+        /// never down.
+        if (self is TCustomForm) and TCustomForm(self).ScalingDesign then
+        begin
+          Style.SetProperty('min-width', IntToStr(Trunc(AdjustWithPPI(FWidth) * TCustomForm(self).HorizontalScale)) + 'px');
+          Style.SetProperty('min-height', IntToStr(Trunc(AdjustWithPPI(FHeight) * TCustomForm(self).VerticalScale)) + 'px');
+        end;
       end;
 
       /// Cursor

--- a/widgets/controls.pas
+++ b/widgets/controls.pas
@@ -1525,10 +1525,8 @@ end;
 procedure TControl.Changed;
 var
   form: TCustomForm;
-  hscale: Single;
-  vscale: Single;
 
-  function AdjustWithPPI(aValue: Integer): Integer;
+  function AdjustWithPPI(aValue: Integer): Integer; overload;
   begin
     if Assigned(form) then
       Result := Trunc(96 * aValue / form.DesignTimePPI)
@@ -1596,19 +1594,10 @@ begin
       /// Bounds
       if (form <> nil) and form.ScalingDesign and (Parent <> nil) then
       begin
-        hscale := 1;
-        vscale := 1;
-
-        if Parent = form then
-        begin
-          hscale := Parent.HorizontalScale;
-          vscale := Parent.VerticalScale;
-        end;
-
-        Style.SetProperty('left', FloatToStr(AdjustWithPPI(FLeft) / Parent.Width * 100 / hscale) + '%');
-        Style.SetProperty('top', FloatToStr(AdjustWithPPI(FTop) / Parent.Height * 100 / vscale) + '%');
-        Style.SetProperty('width', FloatToStr(AdjustWithPPI(FWidth) / Parent.Width * 100 / hscale) + '%');
-        Style.SetProperty('height', FloatToStr(AdjustWithPPI(FHeight) / Parent.Height * 100 / vscale) + '%');
+        Style.SetProperty('left', FloatToStr(AdjustWithPPI(FLeft) / AdjustWithPPI(Parent.Width) / Parent.HorizontalScale * 100) + '%');
+        Style.SetProperty('top', FloatToStr(AdjustWithPPI(FTop) / AdjustWithPPI(Parent.Height) / Parent.VerticalScale * 100) + '%');
+        Style.SetProperty('width', FloatToStr(AdjustWithPPI(FWidth) / AdjustWithPPI(Parent.Width) / Parent.HorizontalScale * 100) + '%');
+        Style.SetProperty('height', FloatToStr(AdjustWithPPI(FHeight) / AdjustWithPPI(Parent.Height) / Parent.VerticalScale * 100) + '%');
       end
       else
       begin

--- a/widgets/controls.pas
+++ b/widgets/controls.pas
@@ -1594,10 +1594,10 @@ begin
       /// Bounds
       if (form <> nil) and form.ScalingDesign and (Parent <> nil) then
       begin
-        Style.SetProperty('left', FloatToStr(AdjustWithPPI(FLeft) / AdjustWithPPI(Parent.Width) / Parent.HorizontalScale * 100) + '%');
-        Style.SetProperty('top', FloatToStr(AdjustWithPPI(FTop) / AdjustWithPPI(Parent.Height) / Parent.VerticalScale * 100) + '%');
-        Style.SetProperty('width', FloatToStr(AdjustWithPPI(FWidth) / AdjustWithPPI(Parent.Width) / Parent.HorizontalScale * 100) + '%');
-        Style.SetProperty('height', FloatToStr(AdjustWithPPI(FHeight) / AdjustWithPPI(Parent.Height) / Parent.VerticalScale * 100) + '%');
+        Style.SetProperty('left', FloatToStr(FLeft / Parent.Width / Parent.HorizontalScale * 100) + '%');
+        Style.SetProperty('top', FloatToStr(FTop / Parent.Height / Parent.VerticalScale * 100) + '%');
+        Style.SetProperty('width', FloatToStr(FWidth / Parent.Width / Parent.HorizontalScale * 100) + '%');
+        Style.SetProperty('height', FloatToStr(FHeight / Parent.Height / Parent.VerticalScale * 100) + '%');
       end
       else
       begin

--- a/widgets/controls.pas
+++ b/widgets/controls.pas
@@ -2314,6 +2314,7 @@ begin
     end;
     Changed;
     ReAlign;
+    DoResize;
   end;
 end;
 

--- a/widgets/controls.pas
+++ b/widgets/controls.pas
@@ -1594,10 +1594,20 @@ begin
       /// Bounds
       if (form <> nil) and form.ScalingDesign and (Parent <> nil) then
       begin
-        Style.SetProperty('left', FloatToStr(FLeft / Parent.Width / form.HorizontalScale * 100) + '%');
-        Style.SetProperty('top', FloatToStr(FTop / Parent.Height / form.VerticalScale * 100) + '%');
-        Style.SetProperty('width', FloatToStr(FWidth / Parent.Width / form.HorizontalScale * 100) + '%');
-        Style.SetProperty('height', FloatToStr(FHeight / Parent.Height / form.VerticalScale * 100) + '%');
+        if Parent = form then
+        begin
+          Style.SetProperty('left', FloatToStr(FLeft / Parent.Width / form.HorizontalScale * 100) + '%');
+          Style.SetProperty('top', FloatToStr(FTop / Parent.Height / form.VerticalScale * 100) + '%');
+          Style.SetProperty('width', FloatToStr(FWidth / Parent.Width / form.HorizontalScale * 100) + '%');
+          Style.SetProperty('height', FloatToStr(FHeight / Parent.Height / form.VerticalScale * 100) + '%');
+        end
+        else
+        begin
+          Style.SetProperty('left', FloatToStr(FLeft / Parent.Width * 100) + '%');
+          Style.SetProperty('top', FloatToStr(FTop / Parent.Height * 100) + '%');
+          Style.SetProperty('width', FloatToStr(FWidth / Parent.Width * 100) + '%');
+          Style.SetProperty('height', FloatToStr(FHeight / Parent.Height * 100) + '%');
+        end;
       end
       else
       begin

--- a/widgets/controls.pas
+++ b/widgets/controls.pas
@@ -341,6 +341,7 @@ type
     procedure ReAlign; virtual; /// Realign all children
     procedure BringToFront; virtual;
     procedure SendToBack; virtual;
+    procedure Repaint; virtual;
     procedure SetBounds(ALeft, ATop, AWidth, AHeight: NativeInt); virtual;
   public
     property Align: TAlign read FAlign write SetAlign;
@@ -404,6 +405,8 @@ type
     procedure UnRegisterHandleEvents; override;
     function CheckChildClassAllowed(AChildClass: TClass): boolean; override;
     function FindFocusControl(const AStartControl: TWinControl; ADirection: TFocusSearchDirection): TWinControl; virtual;
+  public
+    procedure Repaint; override;
   public
     function Focused: boolean; virtual;
     function CanSetFocus: boolean; virtual;
@@ -1223,6 +1226,7 @@ begin
       begin
         FShowHint := FParent.ShowHint;
       end;
+      Repaint;
     finally
       EndUpdate;
     end;
@@ -2259,6 +2263,12 @@ begin
   end;
 end;
 
+procedure TControl.Repaint;
+begin
+  { draws the control in JS }
+  Changed;
+end;
+
 procedure TControl.SetBounds(ALeft, ATop, AWidth, AHeight: NativeInt);
 begin
   { TODO: Constraint max min width and height }
@@ -2627,6 +2637,17 @@ begin
    end
   finally
     VArray.Length := 0;
+  end;
+end;
+
+procedure TWinControl.Repaint;
+var
+  I: NativeInt;
+begin
+  inherited Repaint;
+  for I := 0 to ControlCount - 1 do
+  begin
+    GetControl(I).Repaint;
   end;
 end;
 

--- a/widgets/forms.pas
+++ b/widgets/forms.pas
@@ -108,6 +108,8 @@ type
     FOnScroll: TNotifyEvent;
     FOnShow: TNotifyEvent;
     FScalingDesign: Boolean;
+    FHorizontalScale: Single;
+    FVerticalScale: Single;
     procedure SetActiveControl(AValue: TWinControl);
     procedure SetAlphaBlend(AValue: boolean);
     procedure SetAlphaBlendValue(AValue: byte);
@@ -170,6 +172,8 @@ type
     property OnScroll: TNotifyEvent read FOnScroll write FOnScroll;
     property OnShow: TNotifyEvent read FOnShow write FOnShow;
     property ScalingDesign: Boolean read FScalingDesign write SetScalingDesign;
+    property HorizontalScale: Single read FHorizontalScale write FHorizontalScale;
+    property VerticalScale: Single read FVerticalScale write FVerticalScale;
   end;
   TCustomFormClass = class of TCustomForm;
 
@@ -740,7 +744,6 @@ end;
 constructor TCustomForm.Create(AOwner: TComponent);
 begin
   CreateNew(AOwner, 1);
-  FScalingDesign := False;
   if (ClassType <> TWForm) and not (csDesigning in ComponentState) then begin
     ProcessResource;
   end;
@@ -759,6 +762,9 @@ begin
   FModalResult := mrNone;
   FModalResultProc := nil;
   FOverlay := nil;
+  FScalingDesign := False;
+  FHorizontalScale := 1;
+  FVerticalScale := 1;
   BorderStyle := bsSizeable;
   BeginUpdate;
   try

--- a/widgets/forms.pas
+++ b/widgets/forms.pas
@@ -596,7 +596,7 @@ begin
   if (FScalingDesign <> AValue) then
   begin
     FScalingDesign := AValue;
-    Changed;
+    Repaint;
   end;
 end;
 
@@ -896,12 +896,11 @@ end;
 
 procedure TCustomForm.Resize;
 var
-  VHeight: NativeInt;
-  VLeft: NativeInt;
-  VTop: NativeInt;
-  VWidth: NativeInt;
-  VWindowHeight: NativeInt;
-  VWindowWidth: NativeInt;
+  VOwner: TCustomForm;
+  VLeft, VTop: NativeInt;
+  VWidth, VHeight: NativeInt;
+  VCalculatedSize: Single;
+  VWindowWidth, VWindowHeight: NativeInt;
 begin
   VWindowWidth := Window.InnerWidth;
   VWindowHeight := Window.InnerHeight;
@@ -911,6 +910,21 @@ begin
   case FFormType of
     ftModalForm:
     begin
+      VOwner := TCustomForm(Owner);
+      if FScalingDesign then
+      begin
+        VCalculatedSize := VWidth * FHorizontalScale / VOwner.HorizontalScale;
+        VWidth := Trunc(VCalculatedSize);
+        FHorizontalScale := VOwner.HorizontalScale * (VCalculatedSize / VWidth);
+        VCalculatedSize := VHeight * FVerticalScale / VOwner.VerticalScale;
+        VHeight := Trunc(VCalculatedSize);
+        FVerticalScale := VOwner.VerticalScale * (VCalculatedSize / VHeight);
+      end
+      else
+      begin
+        FHorizontalScale := VOwner.HorizontalScale;
+        FVerticalScale := VOwner.VerticalScale;
+      end;
       VLeft := (VWindowWidth - VWidth) div 2;
       VTop := (VWindowHeight - VHeight) div 2;
       SetBounds(VLeft, VTop, VWidth, VHeight);

--- a/widgets/forms.pas
+++ b/widgets/forms.pas
@@ -907,8 +907,6 @@ begin
   VWindowHeight := Window.InnerHeight;
   VWidth := Width;
   VHeight := Height;
-  HorizontalScale := HorizontalScale * VWidth / VWindowWidth;
-  VerticalScale := VerticalScale * VHeight / VWindowHeight;
 
   case FFormType of
     ftModalForm:
@@ -919,6 +917,8 @@ begin
     end;
     ftWindow:
     begin
+      FHorizontalScale := FHorizontalScale * VWidth / VWindowWidth;
+      FVerticalScale := FVerticalScale * VHeight / VWindowHeight;
       SetBounds(0, 0, VWindowWidth, VWindowHeight);
     end;
   end;


### PR DESCRIPTION
This feature adds ScalingDesign flag to TWForm classes. With this flag enabled, the design will be scaled up so that Lazarus design will represent the entire browser screen (instead of being fixed size).

It works by calculating offsets / widths of each element in relation to its parent's width / height and including it as % value instead of pixel value. It also adds a HorizontalScale / VerticalScale properties, which are mostly used for the form's width and height (which gets resized to have full browser window width and height).

With this simple design:
![image](https://github.com/user-attachments/assets/fa4df50b-25dd-4183-ad8b-e96ebd61538c)
Without ScalingDesign (empty space can be seen since my screen is bigger than the design):
![image](https://github.com/user-attachments/assets/797c0252-a62a-4507-8326-461f0af576f4)
With ScalingDesign:
![image](https://github.com/user-attachments/assets/d4195f65-222f-4839-92cc-46260ef537b2)

- May need a bit of tweaking around naming of new Scale properties, since they may be misleading (they do not affect the scale of the object, but rather only its children - they are needed to keep track of how much the object was scaled thus far)
- May need implementing for TWFrame - TBD

*A bunch of whitespace changes since my editor is set to auto-fix them. Let me know if you want me to skip adding these.*