### PR TITLE
Fix default colors being added to HTML styles

### DIFF
--- a/widgets/controls.pas
+++ b/widgets/controls.pas
@@ -1569,26 +1569,23 @@ begin
       begin
         RemoveAttribute('class');
       end;
-                    
+
+      /// Font color
+      if FFont.Color = clDefault then
+        Style.RemoveProperty('color')
+      else
+        Style.SetProperty('color', JSColor(FFont.Color));
+
+      /// Background color
+      if FColor = clDefault then
+        Style.RemoveProperty('background-color')
+      else
+        Style.SetProperty('background-color', JSColor(FColor));
+
       /// Style
       if (FHandleClass = '') and (FHandleId = '') then
-      begin      
-        /// Font
-        if FFont.Color in [clDefault, clNone] then
-          Style.RemoveProperty('color')
-        else
-          Style.SetProperty('color', JSColor(FFont.Color));
+      begin
         UpdateHtmlElementFont(FHandleElement, FFont, False);
-
-        /// Color
-        if (FColor in [clDefault, clNone]) then
-        begin
-          Style.RemoveProperty('background-color');
-        end
-        else
-        begin
-          Style.SetProperty('background-color', JSColor(FColor));
-        end;
       end;
 
       /// Bounds

--- a/widgets/controls.pas
+++ b/widgets/controls.pas
@@ -1574,8 +1574,12 @@ begin
       if (FHandleClass = '') and (FHandleId = '') then
       begin      
         /// Font
-        Style.SetProperty('color', JSColor(FFont.Color));
+        if FFont.Color in [clDefault, clNone] then
+          Style.RemoveProperty('color')
+        else
+          Style.SetProperty('color', JSColor(FFont.Color));
         UpdateHtmlElementFont(FHandleElement, FFont, False);
+
         /// Color
         if (FColor in [clDefault, clNone]) then
         begin

--- a/widgets/forms.pas
+++ b/widgets/forms.pas
@@ -748,7 +748,6 @@ begin
   BorderStyle := bsSizeable;
   BeginUpdate;
   try
-    Color := clWhite;
     ParentFont := False;
     ParentShowHint := False;
     Visible := False;

--- a/widgets/graphics.pas
+++ b/widgets/graphics.pas
@@ -328,6 +328,7 @@ begin
     cl3DLight: Result := 'ThreeDHighlight';
     clInfoText: Result := 'InfoText';
     clInfoBk: Result := 'InfoBackground';
+    clNone: Result := 'Transparent';
     else
     begin
       R := (AColor) and $FF;

--- a/widgets/graphics.pas
+++ b/widgets/graphics.pas
@@ -389,7 +389,7 @@ end;
 { TFont }
 
 function TFont.GetHeight: NativeInt;
-begin                            
+begin
   /// https://stackoverflow.com/questions/139655/convert-pixels-to-points
   Result := Round((- FSize * 72) / 96);
 end;
@@ -456,7 +456,7 @@ end;
 constructor TFont.Create;
 begin
   inherited Create;
-  FColor := clBlack;
+  FColor := clDefault;
   FName := ffSans;
   FSize := 10;
   FStyle := [];


### PR DESCRIPTION
This commit does two things which help immensely when styling the document:
- it adds the same handling of font color as background colors, which also resolves #29 
- it removes some erroneous assignment of non-default colors (white for form background, black for all font colors), which caused these if statements to not work at all

These changes fix some problems with css frameworks, and allow for dark mode.