### PR TITLE
Fix setting border-style 'none'

### DIFF
--- a/widgets/forms.pas
+++ b/widgets/forms.pas
@@ -566,7 +566,7 @@ begin
   if AValue in [Low(TBorderStyle)..High(TBorderStyle)] then
     bs := AValue
   else
-    bs := bsNone;
+    bs := bsSingle;
 
   inherited SetBorderStyle(bs);
 end;


### PR DESCRIPTION
This is an easy fix to sometimes not being able to set border through CSS. The default value of control's BorderStyle is bsSingle, so set it instead of bsNone. There is no reason to set bsNone if there is some kind of border (but not known to TControl).

This is useful for example to give modal form a border.